### PR TITLE
Add network analyzer selection for SCO and POS systems

### DIFF
--- a/assets/command_get_sco_type.ps1
+++ b/assets/command_get_sco_type.ps1
@@ -45,6 +45,7 @@ $scriptBlock = {
         ipAddress = $system.IPv4Address
         Motherboard = 'N/A'
         Printer = $null
+        NetworkAnalyzer = 'Not Available' # P00c3
     }
 
     # Quick ping check with timeout
@@ -192,6 +193,18 @@ $scriptBlock = {
                     Remove-CimSession -CimSession $cimSession -ErrorAction SilentlyContinue
                 }
             }
+
+            # Retrieve network analyzer information
+            try {
+                $networkAnalyzerPath = "\\$($system.Name)\c$\Program Files\NetworkAnalyzer\config.xml"
+                if (Test-Path $networkAnalyzerPath) {
+                    $networkAnalyzerConfig = [xml](Get-Content $networkAnalyzerPath)
+                    $systemInfo.NetworkAnalyzer = $networkAnalyzerConfig.SelectSingleNode("//Analyzer/Type").InnerText
+                }
+            } catch {
+                Write-Warning "Error retrieving network analyzer information for $($system.Name): $_"
+                $systemInfo.NetworkAnalyzer = "Not Available"
+            }
         }
         catch {
             Write-Warning "Error processing $($system.Name): $_"
@@ -200,6 +213,7 @@ $scriptBlock = {
             $systemInfo.Architecture = "Not Available"
             $systemInfo.Motherboard = "Not Available"
             $systemInfo.Printer = "Not Available"
+            $systemInfo.NetworkAnalyzer = "Not Available" # Pdbda
         }
     }
 
@@ -250,6 +264,7 @@ try {
             ipAddress = if ($_.ipAddress) { $_.ipAddress } else { "Not Available" }
             Motherboard = if ($_.Motherboard) { $_.Motherboard } else { "Not Available" }
             Printer = if ($_.Printer) { $_.Printer } else { "Not Available" }
+            NetworkAnalyzer = if ($_.NetworkAnalyzer) { $_.NetworkAnalyzer } else { "Not Available" } # Pdbda
         }
         $cleanSystem
     }

--- a/public/electron.js
+++ b/public/electron.js
@@ -809,3 +809,46 @@ safeIpcHandler('disconnect-status', async (event, systemName) => {
   }
   return { success: true };
 });
+
+// Add IPC handlers for network analyzer selection
+safeIpcHandler('get-network-analyzer-info', async (event, systemName) => {
+  return new Promise((resolve, reject) => {
+    const scriptPath = path.join(process.resourcesPath, 'assets', 'get_network_analyzer_info.ps1');
+    const command = `powershell.exe -ExecutionPolicy Bypass -File "${scriptPath}" -systemName "${systemName}"`;
+
+    console.log('Executing command:', command);
+
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error executing PowerShell script: ${error}`);
+        reject(error);
+        return;
+      }
+      if (stderr) {
+        console.error(`PowerShell script stderr: ${stderr}`);
+      }
+      resolve(stdout);
+    });
+  });
+});
+
+safeIpcHandler('set-network-analyzer', async (event, systemName, analyzerType) => {
+  return new Promise((resolve, reject) => {
+    const scriptPath = path.join(process.resourcesPath, 'assets', 'set_network_analyzer.ps1');
+    const command = `powershell.exe -ExecutionPolicy Bypass -File "${scriptPath}" -systemName "${systemName}" -analyzerType "${analyzerType}"`;
+
+    console.log('Executing command:', command);
+
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error executing PowerShell script: ${error}`);
+        reject(error);
+        return;
+      }
+      if (stderr) {
+        console.error(`PowerShell script stderr: ${stderr}`);
+      }
+      resolve(stdout);
+    });
+  });
+});

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -17,10 +17,6 @@ const { ipcRenderer } = window.require('electron');
 import '../styles/Dashboard.css';
 import { VncScreen } from 'react-vnc';
 
-
-
-
-
 export interface SystemCardData {
   name: string;
   type: string;
@@ -31,6 +27,7 @@ export interface SystemCardData {
     ipAddress?: string;
     Motherboard?: string;
     Printer?: string;
+    NetworkAnalyzer?: string; // Add this line
   };
 }
 
@@ -327,7 +324,8 @@ const Dashboard: React.FC<DashboardProps> = ({ onLogout }) => {
             IsOnline: system.IsOnline || false,
             ipAddress: system.ipAddress || 'Not Available',
             Motherboard: system.Motherboard || 'Not Available',
-            Printer: system.Printer || 'Not Available'
+            Printer: system.Printer || 'Not Available',
+            NetworkAnalyzer: system.NetworkAnalyzer || 'Not Available' // Add this line
           }
         };
 


### PR DESCRIPTION
Add functionality to allow users to select SCO or POS systems to network analyzer.

* **assets/command_get_sco_type.ps1**
  - Add logic to integrate with network analyzer.
  - Update script to retrieve network analyzer information.
  - Add NetworkAnalyzer field to system information.

* **src/components/Dashboard.tsx**
  - Add NetworkAnalyzer field to SystemCardData interface.
  - Update system search and display to include network analyzer information.

* **public/electron.js**
  - Add IPC handlers for network analyzer selection.
  - Add handlers to retrieve and set network analyzer information.

