### PR TITLE
Add network analyzer for SCO and POS systems

### DIFF
--- a/src/components/SystemCard.tsx
+++ b/src/components/SystemCard.tsx
@@ -17,6 +17,7 @@ interface SystemCardProps {
     ipAddress?: string;
     Motherboard?: string;
     Printer?: string;
+    NetworkAnalyzer?: string; // Add this line
   };
   onDetailsClick: () => void;
   onOpenParser: (systemName: string) => void;
@@ -222,6 +223,9 @@ const SystemCard: React.FC<SystemCardProps> = ({ name, type, details, onDetailsC
               <p className="system-card__detail"><strong>Printer:</strong> {details.Printer}</p>
             )}
           </>
+        )}
+        {details.NetworkAnalyzer && ( // Add this block
+          <p className="system-card__detail"><strong>Network Analyzer:</strong> {details.NetworkAnalyzer}</p>
         )}
       </div>
       <div className="system-card__footer">


### PR DESCRIPTION
Add network analyzer information to system card details.

* Add `NetworkAnalyzer` property to `SystemCard` interface.
* Display network analyzer information in system card details if available.

